### PR TITLE
Introduce a `allowed_cookies` whitelist and set this as new default.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,17 @@ Changelog
 2.1 (unreleased)
 ----------------
 
+Breaking change:
+
+- Introduce a `allowed_cookies` whitelist and set this as new default.
+  To send cookies you need to enable the `send_cookies` switch and define all
+  the cookies you want to send in `allowed_cookies`. An empty `allowed_cookies`
+  setting will not send any cookies, even if `send_cookies` is active. You can
+  use the `*` wildcard to match zero or more characters.
+  [thet]
+
+Bugfixes:
+
 - Don't break, if plone.tiles is not installed.
   [thet]
 

--- a/src/collective/remoteproxy/browser/common.py
+++ b/src/collective/remoteproxy/browser/common.py
@@ -5,6 +5,7 @@ from urllib import parse
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 
+
 try:
     from plone.tiles.tile import Tile
 except ImportError:
@@ -51,6 +52,7 @@ class RemoteProxyBaseView:
             auth_user=getattr(self.context, "auth_user", None),
             auth_pass=getattr(self.context, "auth_pass", None),
             cookies=cookies,
+            allowed_cookies=getattr(self.context, "allowed_cookies", ()),
             cache_time=getattr(self.context, "cache_time", 3600),
             standalone=IUUID(self.context)
             if getattr(self.context, "standalone", False)

--- a/src/collective/remoteproxy/interfaces.py
+++ b/src/collective/remoteproxy/interfaces.py
@@ -110,6 +110,20 @@ class IRemoteProxySchema(Interface):
         default=False,
     )
 
+    allowed_cookies = schema.Tuple(
+        title=_("label_allowed_cookies", default="Allowed cookies"),
+        description=_(
+            "help_allowed_cookies",
+            default="Define the cookies which will be sent to the remote, one per line. "
+            "Only listed cookies are sent. Use * as a wildcard for zero or more "
+            "characters. Leave empty to send no cookies.",
+        ),
+        value_type=schema.TextLine(),
+        required=False,
+        default=(),
+        missing_value=(),
+    )
+
     standalone = schema.Bool(
         title=_(
             "label_standalone",

--- a/src/collective/remoteproxy/portlets/portlet.py
+++ b/src/collective/remoteproxy/portlets/portlet.py
@@ -8,7 +8,6 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope import schema
 from zope.interface import implementer
 
-
 PLONE5 = getFSVersionTuple()[0] >= 5
 
 if PLONE5:
@@ -52,6 +51,7 @@ class Assignment(base.Assignment):
         auth_user,
         auth_pass,
         send_cookies,
+        allowed_cookies,
         cache_time,
     ):
         self.header = header
@@ -63,6 +63,7 @@ class Assignment(base.Assignment):
         self.auth_user = auth_user
         self.auth_pass = auth_pass
         self.send_cookies = send_cookies
+        self.allowed_cookies = allowed_cookies
         self.cache_time = cache_time
 
     @property
@@ -87,10 +88,11 @@ class Renderer(base.Renderer):
             content_selector=self.data.content_selector,
             keep_scripts=self.data.keep_scripts,
             keep_styles=self.data.keep_styles,
-            extra_replacements=self.extra_replacements,
+            extra_replacements=self.data.extra_replacements,
             auth_user=self.data.auth_user,
             auth_pass=self.data.auth_pass,
             cookies=cookies,
+            allowed_cookies=self.data.allowed_cookies,
             cache_time=self.data.cache_time,
         )
         return content

--- a/src/collective/remoteproxy/remoteproxy.py
+++ b/src/collective/remoteproxy/remoteproxy.py
@@ -20,6 +20,46 @@ TEXT_TYPES = (
 )
 
 
+def _cookie_name_matches(name, pattern):
+    """Return whether a cookie name matches an allow-list pattern.
+
+    The only supported wildcard is ``*``, which matches zero or more
+    characters.  All other characters are treated literally.
+    """
+
+    parts = pattern.split("*")
+    if len(parts) == 1:
+        return name == pattern
+
+    if not name.startswith(parts[0]):
+        return False
+    if parts[-1] and not name.endswith(parts[-1]):
+        return False
+
+    position = len(parts[0])
+    end = len(name) - len(parts[-1]) if parts[-1] else len(name)
+    for part in parts[1:-1]:
+        position = name.find(part, position, end)
+        if position == -1:
+            return False
+        position += len(part)
+    return position <= end
+
+
+def _filter_cookies(cookies, allowed_cookies):
+    """Return only cookies whose names are explicitly allowed."""
+
+    if not cookies:
+        return {}
+
+    allowed_cookies = [pattern for pattern in allowed_cookies if pattern]
+    return {
+        str(name): safe_text(value, encoding="latin-1")
+        for name, value in cookies.items()
+        if any(_cookie_name_matches(str(name), pattern) for pattern in allowed_cookies)
+    }
+
+
 def _results_cachekey(
     method,
     remote_url,
@@ -30,6 +70,7 @@ def _results_cachekey(
     auth_user="",
     auth_pass="",
     cookies=None,
+    allowed_cookies=(),
     cache_time=3600,
     standalone=None,
 ):
@@ -47,6 +88,7 @@ def _results_cachekey(
         auth_user,
         auth_pass,
         cookies,
+        allowed_cookies,
         timeout,
         standalone,
     )
@@ -63,6 +105,7 @@ def get_content(
     auth_user="",
     auth_pass="",
     cookies=None,
+    allowed_cookies=(),
     cache_time=3600,
     standalone=None,
 ):
@@ -90,17 +133,8 @@ def get_content(
         # Replace text in URLs.
         remote_url = remote_url.replace(repl[0], repl[1])
 
-    if cookies:
-        # encode cookie values as latin-1, as cookies are http byte
-        # values which directly map to latin-1. Text within cookies
-        # can hava a different encoding, but the latin-1 encoding
-        # here doesn't mess things up.
-        cookies = {
-            str(name): safe_text(value, encoding="latin-1")
-            .replace("\r", "")
-            .replace("\n", "")
-            for name, value in cookies.items()
-        }
+    # An empty allow-list deliberately sends no cookies.
+    cookies = _filter_cookies(cookies, allowed_cookies)
 
     res = requests.get(remote_url, auth=auth, cookies=cookies)
     content_type = res.headers["Content-Type"]

--- a/src/collective/remoteproxy/tests/test_cookies.py
+++ b/src/collective/remoteproxy/tests/test_cookies.py
@@ -1,0 +1,37 @@
+from ..remoteproxy import _cookie_name_matches
+from ..remoteproxy import _filter_cookies
+
+import unittest
+
+
+class CookieFilterTest(unittest.TestCase):
+
+    def test_exact_name(self):
+        self.assertTrue(_cookie_name_matches("session", "session"))
+        self.assertFalse(_cookie_name_matches("session_id", "session"))
+
+    def test_prefix_wildcard(self):
+        self.assertTrue(_cookie_name_matches("_ga_ABC123", "_ga_*"))
+        self.assertFalse(_cookie_name_matches("ga_ABC123", "_ga_*"))
+
+    def test_postfix_wildcard(self):
+        self.assertTrue(_cookie_name_matches("auth_backup", "*_backup"))
+        self.assertFalse(_cookie_name_matches("auth_backup_2", "*_backup"))
+
+    def test_middle_wildcard(self):
+        self.assertTrue(_cookie_name_matches("tenant_user_token", "tenant_*_token"))
+        self.assertFalse(_cookie_name_matches("tenant_user_id", "tenant_*_token"))
+
+    def test_other_characters_are_literal(self):
+        self.assertTrue(_cookie_name_matches("cookie[1]", "cookie[1]"))
+        self.assertFalse(_cookie_name_matches("cookie1", "cookie[1]"))
+
+    def test_empty_allow_list_sends_no_cookies(self):
+        self.assertEqual(_filter_cookies({"session": "secret"}, ()), {})
+
+    def test_filtering_matches_names_and_preserves_values(self):
+        cookies = {"_ga_ABC123": "value", "session": "secret"}
+        self.assertEqual(
+            _filter_cookies(cookies, ("_ga_*",)),
+            {"_ga_ABC123": "value"},
+        )


### PR DESCRIPTION
To send cookies you need to enable the `send_cookies` switch and define all the cookies you want to send in `allowed_cookies`. An empty `allowed_cookies` setting will not send any cookies, even if `send_cookies` is active. You can use the `*` wildcard to match zero or more characters.